### PR TITLE
Client JS works with deeper paths

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import { Provider } from 'react-redux';
 import { Router } from 'react-router-dom';
 import history from './history';
@@ -7,11 +7,12 @@ import store from './store';
 import App from './App';
 import './style.css';
 
-ReactDOM.render(
+const container = document.getElementById('app');
+const root = createRoot(container);
+root.render(
   <Provider store={store}>
     <Router history={history}>
       <App />
     </Router>
   </Provider>,
-  document.getElementById('app'),
 );

--- a/public/index.html
+++ b/public/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width initial-scale=1.0" />
     <title>TestBrew</title>
-    <script defer src="bundle.js"></script>
+    <script defer src="/bundle.js"></script>
   </head>
   <body>
     <div id="app"></div>


### PR DESCRIPTION
If routes are deeper, i.e. `/jest/1`, the browser will look for `bundle.js`  in `http://localhost:8080/jest/bundle.js`

It should be looking for the bundle in `http://localhost:8080/bundle.js` instead.

In the `index.html`, beginning the path with `/` will have the browser see the absolute path towards the correct path `http://localhost:8080/bundle.js`

![Screen Shot 2022-10-08 at 6 39 32 PM](https://user-images.githubusercontent.com/4698973/194730131-97780dfa-cfdc-43f7-8894-acddfdb877ae.png)
